### PR TITLE
Update tokens_search.html

### DIFF
--- a/public/views/tokens_search.html
+++ b/public/views/tokens_search.html
@@ -59,7 +59,7 @@
                 <div class="td">{{ $root.token.convertDecimals(contract.total_supply, contract.decimals) }}</div>
                 <div class="td">{{ contract.count_holders | numeraljs : '0,0[.][00000000]' }}</div>
                 <div class="td">
-                    <a href="/address/{{ contract.contract_address }}" class="ellipsis mark">{{ contract.contract_address }}</a>
+                    <a href="/token/{{ contract.contract_address }}" class="ellipsis mark">{{ contract.contract_address }}</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
the base-link "/address/{{ contract.contract_address }}" breaks on the website. using the link to the tokens' page works. Can't imagine any other functionality is required.